### PR TITLE
Set WP_CACHE to false when in development

### DIFF
--- a/autobahn.json
+++ b/autobahn.json
@@ -20,7 +20,8 @@
         "SCRIPT_DEBUG": true,
         "AUTOMATIC_UPDATER_DISABLED": true,
         "DISALLOW_FILE_EDIT": false,
-        "DISALLOW_FILE_MODS": false
+        "DISALLOW_FILE_MODS": false,
+        "WP_CACHE": false
       },
       "php": {
         "display_errors": 1


### PR DESCRIPTION
added "WP_CACHE": false setting to development block in the autobahn.json, since caching isn't good for development.

--- 
If a project is committed with WP_CACHE: true in their config block, WordPress will try to use the cache when in development.

This in turn causes PHP warnings, since development environments normally don't have the advance cache file:

`Warning: include(/var/www/public/app/advanced-cache.php): failed to open stream: No such file or directory in /var/www/public/wp/wp-settings.php on line 84
Warning: include(): Failed opening '/var/www/public/app/advanced-cache.php' for inclusion (include_path='.:/usr/share/php') in /var/www/public/wp/wp-settings.php on line 84`

By setting the WP_CACHE value to false in development builds, the cache is disabled, meaning the warning doesn't occur - This is usually desired in development environments.